### PR TITLE
Update now calls correct "find" function

### DIFF
--- a/src/stubs/repository.stub
+++ b/src/stubs/repository.stub
@@ -66,7 +66,7 @@ class {{name}} implements {{name}}Interface
      */
     public function update($id, $data)
     {
-        $entity = $this->findById($id);
+        $entity = $this->find($id);
 
         return $this->save($entity, $data);
     }


### PR DESCRIPTION
I noticed that update calls a findById function in the repository that does not exist. I've changed it to use the existing find($id)
